### PR TITLE
Allow posting to newer version of cloudq

### DIFF
--- a/lib/cloudq/publish.rb
+++ b/lib/cloudq/publish.rb
@@ -16,8 +16,9 @@ module Cloudq
       #   JSON.parse(response)['status'] == 'success'
       # end
       resp = RestClient.post [Cloudq::Connection.url, @queue].join('/'), data, headers
-      JSON.parse(resp)['status'] == 'success'
+      parsed_resp = JSON.parse(resp)
 
+      parsed_resp['status'] == 'success' || parsed_resp['ok'] == true
     end
 
     def jsonize(data)

--- a/spec/cloudq/publish_spec.rb
+++ b/spec/cloudq/publish_spec.rb
@@ -16,7 +16,7 @@ describe Cloudq::Publish do
   end
 
   it 'a job to the queue unsuccessfully' do
-    RestClient.should_receive(:post).and_return(false)
+    RestClient.should_receive(:post).and_return('{"status": "failed"}')
     subject.job('Archive', :hello => :world).should be_false
   end
 

--- a/spec/cloudq/publish_spec.rb
+++ b/spec/cloudq/publish_spec.rb
@@ -7,7 +7,7 @@ describe Cloudq::Publish do
   end
 
   it 'should jsonize job' do
-    subject.send(:jsonize, {:job => {:klass => 'Archive', :args => [{:hello => 'world'}]}}).should == %Q{{"job":{"klass":"Archive","args":[{"hello":"world"}]}}}
+    subject.send(:jsonize, {:job => {:klass => 'Archive', :args => [{:hello => 'world'}]}}).should == %Q{{"job":{"args":[{"hello":"world"}],"klass":"Archive"}}}
   end
 
   it 'a job to the queue successfully' do

--- a/spec/cloudq/publish_spec.rb
+++ b/spec/cloudq/publish_spec.rb
@@ -20,6 +20,15 @@ describe Cloudq::Publish do
     subject.job('Archive', :hello => :world).should be_false
   end
 
+  it 'should successfully post a job to the newer version of cloudq' do
+    RestClient.should_receive(:post).and_return('{"ok": true}')
+    subject.job('Archive', 'awesome','sauce').should be_true
+  end
+
+  it 'should unsuccessfully post a job to the newer version of cloudq' do
+    RestClient.should_receive(:post).and_return('{"ok": false}')
+    subject.job('Archive', 'awesome','sauce').should be_false
+  end
 
 end
 


### PR DESCRIPTION
The issue was that messages were successfully being posted to the latest version of cloudq, but the return value was incorrect.  Cloudq::Publish.job was always returning false when interacting with the latest version of cloudq.
