### PR TITLE
Extend RestClient timeout on GET

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cloudq_client (0.0.7)
+    cloudq_client (0.0.8)
       backports
       json
       rest-client (>= 1.6.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cloudq_client (0.0.6)
+    cloudq_client (0.0.7)
       backports
       json
       rest-client (>= 1.6.1)
@@ -9,11 +9,11 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    backports (2.1.0)
+    backports (3.6.0)
     diff-lcs (1.1.2)
-    json (1.5.1)
-    mime-types (1.16)
-    rest-client (1.6.1)
+    json (1.8.1)
+    mime-types (2.2)
+    rest-client (1.6.7)
       mime-types (>= 1.16)
     rspec (2.5.0)
       rspec-core (~> 2.5.0)

--- a/cloudq_client.gemspec
+++ b/cloudq_client.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rest-client", ">= 1.6.1"
   s.add_dependency "backports", ">= 0"
   s.add_dependency "json", ">= 0"
+  s.license       = 'MIT'
 
   s.files        = Dir.glob("{lib}/**/*") + %w(LICENSE readme.md)
   s.require_path = 'lib'

--- a/lib/cloudq/consume.rb
+++ b/lib/cloudq/consume.rb
@@ -14,7 +14,7 @@ module Cloudq
     end
 
     def get(&block)
-      resp = RestClient.get url
+      resp = RestClient::Request.execute(:method => :get, :url => url, :timeout => 20000, :open_timeout => 20000)
       if resp.code == 200
         result = JSON.parse(resp)
         return nil if result['status'] == 'empty'

--- a/lib/cloudq/version.rb
+++ b/lib/cloudq/version.rb
@@ -1,4 +1,4 @@
 module Cloudq
-  VERSION = '0.0.8'
+  VERSION = '0.1.1'
 end
 

--- a/lib/cloudq/version.rb
+++ b/lib/cloudq/version.rb
@@ -1,4 +1,4 @@
 module Cloudq
-  VERSION = '0.0.7'
+  VERSION = '0.0.8'
 end
 

--- a/spec/cloudq/publish_spec.rb
+++ b/spec/cloudq/publish_spec.rb
@@ -7,7 +7,7 @@ describe Cloudq::Publish do
   end
 
   it 'should jsonize job' do
-    subject.send(:jsonize, {:job => {:klass => 'Archive', :args => [{:hello => 'world'}]}}).should == %Q{{"job":{"args":[{"hello":"world"}],"klass":"Archive"}}}
+    subject.send(:jsonize, {:job => {:klass => 'Archive', :args => [{:hello => 'world'}]}}).should == %Q{{"job":{"klass":"Archive","args":[{"hello":"world"}]}}}
   end
 
   it 'a job to the queue successfully' do


### PR DESCRIPTION
This resolves an issue where a RestClient timeout is occurring on the get request for consume.  It appears that this is occurring for applications that are using the Cloudq 2.7.1. 
