### PR TITLE
Set timeout on request

### DIFF
--- a/lib/cloudq/consume.rb
+++ b/lib/cloudq/consume.rb
@@ -14,7 +14,7 @@ module Cloudq
     end
 
     def get(&block)
-      resp = RestClient::Request.execute(:method => :get, :url => url, :timeout => 20000, :open_timeout => 20000)
+      resp = RestClient::Request.execute(:method => :get, :url => url, :timeout => 300, :open_timeout => 300)
       if resp.code == 200
         result = JSON.parse(resp)
         return nil if result['status'] == 'empty'

--- a/lib/cloudq/request.rb
+++ b/lib/cloudq/request.rb
@@ -1,13 +1,13 @@
 module Cloudq
   class Request < Base
     def job
-      get 
+      get
     end
 
   private
 
     def get
-      resp = RestClient.get url
+      resp = RestClient::Request.execute(:method => :get, :url => url, :timeout => 300, :open_timeout => 300)
       if resp.code == 200
         result = JSON.parse(resp)
         return nil if result['status'] == 'empty'

--- a/lib/cloudq/version.rb
+++ b/lib/cloudq/version.rb
@@ -1,4 +1,4 @@
 module Cloudq
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end
 


### PR DESCRIPTION
A timeout was added to the Request.get restclient request to accomodate the latest version of cloudq.

Since the timeout is specified in seconds

```
### from rest_client Request source
  # * :timeout and :open_timeout are how long to wait for a response and to
  #     open a connection, in seconds. Pass nil to disable the timeout.
```

I set the timeout to 300 which should be sufficient to handle the 100 sec wait time in cloudq if no messages are on the queue.  But still allow the request to timeout eventually if no response is received.
